### PR TITLE
anchoring PPEO ontology terms to existing OBO foundry ontologies 

### DIFF
--- a/PPEO.owl
+++ b/PPEO.owl
@@ -1211,6 +1211,8 @@
             </owl:Class>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.org/ppeo/PPEO.owl#location"/>
+        <hasOntologyRecommendation>cartesian spartial coordinate datum
+http://purl.obolibrary.org/obo/IAO_0000400</hasOntologyRecommendation>
         <rdfs:label xml:lang="en">GPS location</rdfs:label>
     </owl:Class>
     
@@ -1276,6 +1278,8 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <hasBrAPISynonym xml:lang="en">germplasm</hasBrAPISynonym>
+        <hasOntologyRecommendation>material sample
+http://purl.obolibrary.org/obo/OBI_0000747</hasOntologyRecommendation>
         <rdfs:comment xml:lang="en">An organism that was the subject of the study and/or was observed in an observation unit.</rdfs:comment>
         <rdfs:label xml:lang="en">biological material</rdfs:label>
     </owl:Class>
@@ -1310,6 +1314,7 @@
                 <owl:someValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
             </owl:Restriction>
         </rdfs:subClassOf>
+        <hasOntologyRecommendation>national geopolitical entity: (http://purl.obolibrary.org/obo/ENVO_00000009)</hasOntologyRecommendation>
         <rdfs:comment xml:lang="en">A country in the world that either presently exists (i.e. is recognized in status by most entities) or existed at the time of the study.</rdfs:comment>
         <rdfs:label xml:lang="en">country</rdfs:label>
     </owl:Class>
@@ -1347,6 +1352,8 @@
                 <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
             </owl:Restriction>
         </rdfs:subClassOf>
+        <hasOntologyRecommendation>data set:
+(http://purl.obolibrary.org/obo/IAO_0000100)</hasOntologyRecommendation>
         <rdfs:comment xml:lang="en">A description of and link to a file or data stream holding some or all of the data described by the MIAPPE submission.</rdfs:comment>
         <rdfs:label xml:lang="en">data file</rdfs:label>
     </owl:Class>
@@ -1362,6 +1369,8 @@
                 <owl:someValuesFrom rdf:resource="http://purl.org/ppeo/PPEO.owl#environment_parameter"/>
             </owl:Restriction>
         </rdfs:subClassOf>
+        <hasOntologyRecommendation>environmental feature
+(http://purl.obolibrary.org/obo/ENVO_00002297)</hasOntologyRecommendation>
         <rdfs:comment xml:lang="en">The set of environmental parameters or experimental conditions that were kept constant during the study and did not change betweeen observation units or assays.</rdfs:comment>
         <rdfs:label xml:lang="en">environment</rdfs:label>
     </owl:Class>
@@ -1436,6 +1445,7 @@
                 </owl:onDataRange>
             </owl:Restriction>
         </rdfs:subClassOf>
+        <hasOntologyRecommendation>unplanned occurrence effecting an investigation (http://purl.obolibrary.org/obo/OBI_0000076)</hasOntologyRecommendation>
         <hasRelatedSynonym xml:lang="en">time factor</hasRelatedSynonym>
         <rdfs:comment xml:lang="en">A discrete change to the state of one or more observation units that happened at a given point in time, be it deliberate or inadvertent.</rdfs:comment>
         <rdfs:label xml:lang="en">event</rdfs:label>
@@ -1486,6 +1496,7 @@
                 <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
             </owl:Restriction>
         </rdfs:subClassOf>
+        <hasOntologyRecommendation>http://purl.obolibrary.org/obo/OBI_0000750</hasOntologyRecommendation>
         <rdfs:comment xml:lang="en">A condition that varies between observation units, by taking different values or modalities, assessing the effect of which is the goal of the study. A factor may be biotic (pest, disease interaction) or abiotic (treatment, cultural practice) in nature. It must have at least two values or modalities.</rdfs:comment>
         <rdfs:label xml:lang="en">factor</rdfs:label>
     </owl:Class>
@@ -1517,6 +1528,8 @@
                 </owl:onDataRange>
             </owl:Restriction>
         </rdfs:subClassOf>
+        <hasOntologyRecommendation>factor level
+http://purl.obolibrary.org/obo/STATO_0000265</hasOntologyRecommendation>
         <rdfs:comment xml:lang="en">A value or modality of a factor.</rdfs:comment>
         <rdfs:label xml:lang="en">factor value</rdfs:label>
     </owl:Class>
@@ -1588,6 +1601,7 @@
                 <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
             </owl:Restriction>
         </rdfs:subClassOf>
+        <hasOntologyRecommendation>organization (http://purl.obolibrary.org/obo/OBI_0000245)</hasOntologyRecommendation>
         <rdfs:comment xml:lang="en">An institution (academic or industrial) involved in the investigation or study.</rdfs:comment>
         <rdfs:label xml:lang="en">institution</rdfs:label>
     </owl:Class>
@@ -1645,6 +1659,8 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <hasBrAPISynonym xml:lang="en">trial</hasBrAPISynonym>
+        <hasOntologyRecommendation>investigation
+(http://purl.obolibrary.org/obo/OBI_0000066)</hasOntologyRecommendation>
         <rdfs:comment xml:lang="en">A research programme with defined aims, which can vary in scale from a single experiment, to a grant-funded programme or various components comprising a peer-reviewed publication.</rdfs:comment>
         <rdfs:label xml:lang="en">investigation</rdfs:label>
     </owl:Class>
@@ -1685,6 +1701,8 @@
     <!-- http://purl.org/ppeo/PPEO.owl#location -->
 
     <owl:Class rdf:about="http://purl.org/ppeo/PPEO.owl#location">
+        <hasOntologyRecommendation>geographic location: (/GAZ_00000448)</hasOntologyRecommendation>
+        <hasOntologyRecommendation>site (http://purl.obolibrary.org/obo/BFO_0000029)</hasOntologyRecommendation>
         <rdfs:comment xml:lang="en">A physical location, typically on planet Earth, identified by GPS coordinates and/or name and address.</rdfs:comment>
         <rdfs:label xml:lang="en">location</rdfs:label>
     </owl:Class>
@@ -1780,6 +1798,8 @@
                 </owl:onDataRange>
             </owl:Restriction>
         </rdfs:subClassOf>
+        <hasOntologyRecommendation>protocol:
+(http://purl.obolibrary.org/obo/OBI_0000272)</hasOntologyRecommendation>
         <rdfs:label xml:lang="en">method</rdfs:label>
     </owl:Class>
     <owl:Axiom>
@@ -1829,6 +1849,7 @@
             </owl:Class>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.org/ppeo/PPEO.owl#location"/>
+        <hasOntologyRecommendation>geographic location: (http://purl.obolibrary.org/obo/GAZ_00000448)</hasOntologyRecommendation>
         <rdfs:label xml:lang="en">named location</rdfs:label>
     </owl:Class>
     
@@ -1872,6 +1893,8 @@
                 </owl:allValuesFrom>
             </owl:Restriction>
         </rdfs:subClassOf>
+        <hasOntologyRecommendation>data acquisition/information acquisition
+(http://purl.obolibrary.org/obo/OBI_0600013)</hasOntologyRecommendation>
         <rdfs:label xml:lang="en">observation</rdfs:label>
     </owl:Class>
     
@@ -1944,6 +1967,7 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <hasExactSynonym xml:lang="en">experiment unit</hasExactSynonym>
+        <hasOntologyRecommendation>member_of some &quot;STATO:study group population) (http://purl.obolibrary.org/obo/STATO_0000193)</hasOntologyRecommendation>
         <rdfs:label xml:lang="en">observation unit</rdfs:label>
     </owl:Class>
     
@@ -2016,6 +2040,8 @@
         </rdfs:subClassOf>
         <hasBrAPISynonym xml:lang="en">observation variable</hasBrAPISynonym>
         <hasISASynonym xml:lang="en">assay</hasISASynonym>
+        <hasOntologyRecommendation>variable:
+(http://purl.obolibrary.org/obo/OBI_0000750)</hasOntologyRecommendation>
         <rdfs:label xml:lang="en">observed variable</rdfs:label>
     </owl:Class>
     <owl:Axiom>
@@ -2076,6 +2102,7 @@
                 <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
             </owl:Restriction>
         </rdfs:subClassOf>
+        <hasOntologyRecommendation>type of homo sapiens / bioinformation resource centre contact person (http://purl.obolibrary.org/obo/OBI_0001883)</hasOntologyRecommendation>
         <rdfs:label xml:lang="en">person</rdfs:label>
     </owl:Class>
     
@@ -2110,6 +2137,7 @@
                 <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
             </owl:Restriction>
         </rdfs:subClassOf>
+        <hasOntologyRecommendation>http://purl.obolibrary.org/obo/BFO_0000023</hasOntologyRecommendation>
         <rdfs:label xml:lang="en">role</rdfs:label>
     </owl:Class>
     
@@ -2194,6 +2222,8 @@
                 </owl:onDataRange>
             </owl:Restriction>
         </rdfs:subClassOf>
+        <hasOntologyRecommendation>specimen:
+http://purl.obolibrary.org/obo/OBI_0100051</hasOntologyRecommendation>
         <rdfs:label xml:lang="en">sample</rdfs:label>
     </owl:Class>
     <owl:Axiom>
@@ -2261,6 +2291,8 @@
                 </owl:onDataRange>
             </owl:Restriction>
         </rdfs:subClassOf>
+        <hasOntologyRecommendation>measurement unit label
+(http://purl.obolibrary.org/obo/IAO_0000003)</hasOntologyRecommendation>
         <rdfs:label xml:lang="en">scale</rdfs:label>
     </owl:Class>
     <owl:Axiom>
@@ -2306,6 +2338,8 @@
             </owl:Class>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.org/ppeo/PPEO.owl#spatial_distribution_type"/>
+        <hasOntologyRecommendation>cartesian spartial coordinate datum
+http://purl.obolibrary.org/obo/IAO_0000400</hasOntologyRecommendation>
         <rdfs:label xml:lang="en">spatial coordinate</rdfs:label>
     </owl:Class>
     
@@ -2387,6 +2421,7 @@
                 </owl:onDataRange>
             </owl:Restriction>
         </rdfs:subClassOf>
+        <hasOntologyRecommendation>http://purl.obolibrary.org/obo/OBI_0500000</hasOntologyRecommendation>
         <rdfs:label xml:lang="en">statistical design</rdfs:label>
     </owl:Class>
     <owl:Axiom>
@@ -2537,6 +2572,8 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <hasExactSynonym xml:lang="en">experiment</hasExactSynonym>
+        <hasOntologyRecommendation>investigation
+(http://purl.obolibrary.org/obo/OBI_0000066)</hasOntologyRecommendation>
         <rdfs:comment xml:lang="en">A study (or experiment) comprises a series of assays (or measurements) of one or more types, undertaken to answer a particular biological question.
 It is recommended that a Study have a description.</rdfs:comment>
         <rdfs:label xml:lang="en">study</rdfs:label>
@@ -2599,6 +2636,8 @@ It is recommended that a Study have a description.</rdfs:comment>
                 </owl:onDataRange>
             </owl:Restriction>
         </rdfs:subClassOf>
+        <hasOntologyRecommendation>phenotype:
+(http://purl.obolibrary.org/obo/OGMS_0000023)</hasOntologyRecommendation>
         <rdfs:comment>Name of the (plant or environmental) trait under observation</rdfs:comment>
         <rdfs:label xml:lang="en">trait</rdfs:label>
     </owl:Class>

--- a/PPEO.owl
+++ b/PPEO.owl
@@ -1369,6 +1369,7 @@ http://purl.obolibrary.org/obo/OBI_0000747</hasOntologyRecommendation>
                 <owl:someValuesFrom rdf:resource="http://purl.org/ppeo/PPEO.owl#environment_parameter"/>
             </owl:Restriction>
         </rdfs:subClassOf>
+        <hasOntologyRecommendation>environment system (http://purl.obolibrary.org/obo/ENVO_01000254) as used in AGRO</hasOntologyRecommendation>
         <hasOntologyRecommendation>environmental feature
 (http://purl.obolibrary.org/obo/ENVO_00002297)</hasOntologyRecommendation>
         <rdfs:comment xml:lang="en">The set of environmental parameters or experimental conditions that were kept constant during the study and did not change betweeen observation units or assays.</rdfs:comment>
@@ -1496,6 +1497,9 @@ http://purl.obolibrary.org/obo/OBI_0000747</hasOntologyRecommendation>
                 <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
             </owl:Restriction>
         </rdfs:subClassOf>
+        <hasISASynonym>ISA Study Factor</hasISASynonym>
+        <hasOntologyRecommendation>experimental factor
+http://purl.obolibrary.org/obo/AGRO_00000341</hasOntologyRecommendation>
         <hasOntologyRecommendation>http://purl.obolibrary.org/obo/OBI_0000750</hasOntologyRecommendation>
         <rdfs:comment xml:lang="en">A condition that varies between observation units, by taking different values or modalities, assessing the effect of which is the goal of the study. A factor may be biotic (pest, disease interaction) or abiotic (treatment, cultural practice) in nature. It must have at least two values or modalities.</rdfs:comment>
         <rdfs:label xml:lang="en">factor</rdfs:label>
@@ -1601,7 +1605,7 @@ http://purl.obolibrary.org/obo/STATO_0000265</hasOntologyRecommendation>
                 <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <hasOntologyRecommendation>organization (http://purl.obolibrary.org/obo/OBI_0000245)</hasOntologyRecommendation>
+        <hasOntologyRecommendation>organization (http://purl.obolibrary.org/obo/OBI_0000245) (also used by AGRO)</hasOntologyRecommendation>
         <rdfs:comment xml:lang="en">An institution (academic or industrial) involved in the investigation or study.</rdfs:comment>
         <rdfs:label xml:lang="en">institution</rdfs:label>
     </owl:Class>
@@ -1701,6 +1705,8 @@ http://purl.obolibrary.org/obo/STATO_0000265</hasOntologyRecommendation>
     <!-- http://purl.org/ppeo/PPEO.owl#location -->
 
     <owl:Class rdf:about="http://purl.org/ppeo/PPEO.owl#location">
+        <hasOntologyRecommendation>experimental site:
+http://purl.obolibrary.org/obo/AGRO_00000360</hasOntologyRecommendation>
         <hasOntologyRecommendation>geographic location: (/GAZ_00000448)</hasOntologyRecommendation>
         <hasOntologyRecommendation>site (http://purl.obolibrary.org/obo/BFO_0000029)</hasOntologyRecommendation>
         <rdfs:comment xml:lang="en">A physical location, typically on planet Earth, identified by GPS coordinates and/or name and address.</rdfs:comment>
@@ -1798,6 +1804,7 @@ http://purl.obolibrary.org/obo/STATO_0000265</hasOntologyRecommendation>
                 </owl:onDataRange>
             </owl:Restriction>
         </rdfs:subClassOf>
+        <hasOntologyRecommendation>plan specification (http://purl.obolibrary.org/obo/IAO_0000104) as used in AGRO</hasOntologyRecommendation>
         <hasOntologyRecommendation>protocol:
 (http://purl.obolibrary.org/obo/OBI_0000272)</hasOntologyRecommendation>
         <rdfs:label xml:lang="en">method</rdfs:label>
@@ -2041,7 +2048,7 @@ http://purl.obolibrary.org/obo/STATO_0000265</hasOntologyRecommendation>
         <hasBrAPISynonym xml:lang="en">observation variable</hasBrAPISynonym>
         <hasISASynonym xml:lang="en">assay</hasISASynonym>
         <hasOntologyRecommendation>variable:
-(http://purl.obolibrary.org/obo/OBI_0000750)</hasOntologyRecommendation>
+(http://purl.obolibrary.org/obo/OBI_0000751)</hasOntologyRecommendation>
         <rdfs:label xml:lang="en">observed variable</rdfs:label>
     </owl:Class>
     <owl:Axiom>
@@ -2138,6 +2145,7 @@ http://purl.obolibrary.org/obo/STATO_0000265</hasOntologyRecommendation>
             </owl:Restriction>
         </rdfs:subClassOf>
         <hasOntologyRecommendation>http://purl.obolibrary.org/obo/BFO_0000023</hasOntologyRecommendation>
+        <hasOntologyRecommendation>http://purl.obolibrary.org/obo/CHEBI_50906 (as used by AGRO)</hasOntologyRecommendation>
         <rdfs:label xml:lang="en">role</rdfs:label>
     </owl:Class>
     
@@ -2223,7 +2231,7 @@ http://purl.obolibrary.org/obo/STATO_0000265</hasOntologyRecommendation>
             </owl:Restriction>
         </rdfs:subClassOf>
         <hasOntologyRecommendation>specimen:
-http://purl.obolibrary.org/obo/OBI_0100051</hasOntologyRecommendation>
+http://purl.obolibrary.org/obo/OBI_0100051 (also used by AGRO)</hasOntologyRecommendation>
         <rdfs:label xml:lang="en">sample</rdfs:label>
     </owl:Class>
     <owl:Axiom>
@@ -2291,6 +2299,7 @@ http://purl.obolibrary.org/obo/OBI_0100051</hasOntologyRecommendation>
                 </owl:onDataRange>
             </owl:Restriction>
         </rdfs:subClassOf>
+        <hasOntologyRecommendation>http://purl.obolibrary.org/obo/UO_0000000 (as used in AGRO)</hasOntologyRecommendation>
         <hasOntologyRecommendation>measurement unit label
 (http://purl.obolibrary.org/obo/IAO_0000003)</hasOntologyRecommendation>
         <rdfs:label xml:lang="en">scale</rdfs:label>

--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1531163528215" name="http://purl.org/ppeo/PPEO.owl" uri="PPEO.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1531484770342" name="duplicate:http://purl.org/ppeo/PPEO.owl" uri="PPEO.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1531484770342" name="duplicate:http://purl.org/ppeo/PPEO.owl" uri="old-PPEO-PRS.owl"/>
     </group>
 </catalog>

--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1531484770342" name="duplicate:http://purl.org/ppeo/PPEO.owl" uri="PPEO.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1531484770342" name="duplicate:http://purl.org/ppeo/PPEO.owl" uri="old-PPEO-PRS.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1531485892447" name="duplicate:http://purl.org/ppeo/PPEO.owl" uri="PPEO.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1531485892447" name="duplicate:http://purl.org/ppeo/PPEO.owl" uri="old-PPEO-PRS.owl"/>
     </group>
 </catalog>

--- a/old-PPEO-PRS.owl
+++ b/old-PPEO-PRS.owl
@@ -1,0 +1,1884 @@
+<?xml version="1.0"?>
+<Ontology xmlns="http://www.w3.org/2002/07/owl#"
+     xml:base="http://purl.org/ppeo/PPEO.owl"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:xml="http://www.w3.org/XML/1998/namespace"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     ontologyIRI="http://purl.org/ppeo/PPEO.owl">
+    <Prefix name="" IRI="http://purl.org/ppeo/PPEO.owl"/>
+    <Prefix name="owl" IRI="http://www.w3.org/2002/07/owl#"/>
+    <Prefix name="rdf" IRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+    <Prefix name="xml" IRI="http://www.w3.org/XML/1998/namespace"/>
+    <Prefix name="xsd" IRI="http://www.w3.org/2001/XMLSchema#"/>
+    <Prefix name="PPEO" IRI="http://purl.org/ppeo/PPEO.owl#"/>
+    <Prefix name="rdfs" IRI="http://www.w3.org/2000/01/rdf-schema#"/>
+    <Declaration>
+        <AnnotationProperty IRI="#hasExactSynonym"/>
+    </Declaration>
+    <Declaration>
+        <ObjectProperty IRI="#hasScale"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasSubtaxon"/>
+    </Declaration>
+    <Declaration>
+        <Class IRI="#PPEO_000003"/>
+    </Declaration>
+    <Declaration>
+        <Class IRI="#PPEO_000015"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasTreatmentFactor"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasType"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasReplicationHierarchy"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasReplicationLevels"/>
+    </Declaration>
+    <Declaration>
+        <ObjectProperty IRI="#derivesFrom"/>
+    </Declaration>
+    <Declaration>
+        <ObjectProperty IRI="#partOf"/>
+    </Declaration>
+    <Declaration>
+        <Class IRI="#PPEO_000020"/>
+    </Declaration>
+    <Declaration>
+        <Class IRI="#PPEO_000016"/>
+    </Declaration>
+    <Declaration>
+        <Class IRI="#PPEO_000004"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasAddress"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasCountryCode"/>
+    </Declaration>
+    <Declaration>
+        <ObjectProperty IRI="#hasSetting"/>
+    </Declaration>
+    <Declaration>
+        <ObjectProperty IRI="#hasCountryOfOrigin"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasGenus"/>
+    </Declaration>
+    <Declaration>
+        <Class IRI="#PPEO_000021"/>
+    </Declaration>
+    <Declaration>
+        <ObjectProperty IRI="#hasOccurrence"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasRowId"/>
+    </Declaration>
+    <Declaration>
+        <Class IRI="#PPEO_000005"/>
+    </Declaration>
+    <Declaration>
+        <ObjectProperty IRI="#hasAffiliation"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasGermplasmAccessionNumber"/>
+    </Declaration>
+    <Declaration>
+        <Class IRI="#PPEO_000017"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasDateTime"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasEntryNumber"/>
+    </Declaration>
+    <Declaration>
+        <ObjectProperty IRI="#hasVariable"/>
+    </Declaration>
+    <Declaration>
+        <ObjectProperty IRI="#hasTreatment"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#isActive"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasAssociatedPublication"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasAltitude"/>
+    </Declaration>
+    <Declaration>
+        <ObjectProperty IRI="#hasBiosource"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasMaterialSource"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasLatitude"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasPlantId"/>
+    </Declaration>
+    <Declaration>
+        <ObjectProperty IRI="#hasContactPerson"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasEntryType"/>
+    </Declaration>
+    <Declaration>
+        <Class IRI="#PPEO_000010"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasPlantBody"/>
+    </Declaration>
+    <Declaration>
+        <Class IRI="#PPEO_000022"/>
+    </Declaration>
+    <Declaration>
+        <ObjectProperty IRI="#hasCountry"/>
+    </Declaration>
+    <Declaration>
+        <Class IRI="#PPEO_000018"/>
+    </Declaration>
+    <Declaration>
+        <Class IRI="#PPEO_000006"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasDataFile"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasExperimentalDesign"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasLongitude"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasObservationLevel"/>
+    </Declaration>
+    <Declaration>
+        <ObjectProperty IRI="#hasObservation"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasStartDateTime"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasInstituteCode"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasSubtaxonAuthority"/>
+    </Declaration>
+    <Declaration>
+        <ObjectProperty IRI="#hasCoordinator"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasDatabaseId"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasPlotId"/>
+    </Declaration>
+    <Declaration>
+        <AnnotationProperty IRI="#hasRelatedSynonym"/>
+    </Declaration>
+    <Declaration>
+        <Class IRI="#PPEO_000023"/>
+    </Declaration>
+    <Declaration>
+        <Class IRI="#PPEO_000011"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasLifeStage"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasPublicReleaseDate"/>
+    </Declaration>
+    <Declaration>
+        <Class IRI="#PPEO_000007"/>
+    </Declaration>
+    <Declaration>
+        <Class IRI="#PPEO_000019"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasColumnId"/>
+    </Declaration>
+    <Declaration>
+        <ObjectProperty IRI="#hasStorageLocation"/>
+    </Declaration>
+    <Declaration>
+        <Class IRI="#PPEO_000012"/>
+    </Declaration>
+    <Declaration>
+        <ObjectProperty IRI="#hasOperator"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasSeason"/>
+    </Declaration>
+    <Declaration>
+        <Class IRI="#PPEO_000008"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasSubmissionDate"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasLicense"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasSpeciesAuthority"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasPlantStructureDevelopmentStage"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasIdentifier"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasTaxonId"/>
+    </Declaration>
+    <Declaration>
+        <ObjectProperty IRI="#hasQuality"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasDescription"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasReplicateId"/>
+    </Declaration>
+    <Declaration>
+        <Class IRI="#PPEO_000001"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasTreatmentModality"/>
+    </Declaration>
+    <Declaration>
+        <Class IRI="#PPEO_000013"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasObjective"/>
+    </Declaration>
+    <Declaration>
+        <Class IRI="#PPEO_000009"/>
+    </Declaration>
+    <Declaration>
+        <ObjectProperty IRI="#hasMethod"/>
+    </Declaration>
+    <Declaration>
+        <ObjectProperty IRI="#hasLocation"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasSpecificEpithet"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasBlockId"/>
+    </Declaration>
+    <Declaration>
+        <ObjectProperty IRI="#hasContactInstitution"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasValue"/>
+    </Declaration>
+    <Declaration>
+        <Class IRI="#PPEO_000002"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasAbbreviation"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasOrganismCount"/>
+    </Declaration>
+    <Declaration>
+        <ObjectProperty IRI="#hasParticipatingInstitution"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasMaterialSourceDOI"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasSamplingTime"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasEndDateTime"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasEmailContact"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#hasName"/>
+    </Declaration>
+    <SubClassOf>
+        <Class IRI="#PPEO_000002"/>
+        <ObjectSomeValuesFrom>
+            <ObjectProperty IRI="#partOf"/>
+            <Class IRI="#PPEO_000001"/>
+        </ObjectSomeValuesFrom>
+    </SubClassOf>
+    <SubClassOf>
+        <Class IRI="#PPEO_000002"/>
+        <ObjectMinCardinality cardinality="1">
+            <ObjectProperty IRI="#hasBiosource"/>
+            <Class IRI="#PPEO_000004"/>
+        </ObjectMinCardinality>
+    </SubClassOf>
+    <SubClassOf>
+        <Class IRI="#PPEO_000002"/>
+        <DataExactCardinality cardinality="1">
+            <DataProperty IRI="#hasDescription"/>
+            <Datatype abbreviatedIRI="xsd:string"/>
+        </DataExactCardinality>
+    </SubClassOf>
+    <SubClassOf>
+        <Class IRI="#PPEO_000003"/>
+        <ObjectSomeValuesFrom>
+            <ObjectProperty IRI="#derivesFrom"/>
+            <ObjectUnionOf>
+                <Class IRI="#PPEO_000001"/>
+                <Class IRI="#PPEO_000002"/>
+            </ObjectUnionOf>
+        </ObjectSomeValuesFrom>
+    </SubClassOf>
+    <SubClassOf>
+        <Class IRI="#PPEO_000004"/>
+        <DataExactCardinality cardinality="1">
+            <DataProperty IRI="#hasGenus"/>
+            <Datatype abbreviatedIRI="xsd:string"/>
+        </DataExactCardinality>
+    </SubClassOf>
+    <SubClassOf>
+        <Class IRI="#PPEO_000004"/>
+        <DataExactCardinality cardinality="1">
+            <DataProperty IRI="#hasSpecificEpithet"/>
+            <Datatype abbreviatedIRI="xsd:string"/>
+        </DataExactCardinality>
+    </SubClassOf>
+    <SubClassOf>
+        <Class IRI="#PPEO_000005"/>
+        <ObjectSomeValuesFrom>
+            <ObjectProperty IRI="#partOf"/>
+            <Class IRI="#PPEO_000002"/>
+        </ObjectSomeValuesFrom>
+    </SubClassOf>
+    <SubClassOf>
+        <Class IRI="#PPEO_000006"/>
+        <ObjectExactCardinality cardinality="1">
+            <ObjectProperty IRI="#hasVariable"/>
+            <Class IRI="#PPEO_000007"/>
+        </ObjectExactCardinality>
+    </SubClassOf>
+    <SubClassOf>
+        <Class IRI="#PPEO_000007"/>
+        <ObjectExactCardinality cardinality="1">
+            <ObjectProperty IRI="#hasMethod"/>
+            <Class IRI="#PPEO_000011"/>
+        </ObjectExactCardinality>
+    </SubClassOf>
+    <SubClassOf>
+        <Class IRI="#PPEO_000007"/>
+        <ObjectExactCardinality cardinality="1">
+            <ObjectProperty IRI="#hasQuality"/>
+            <Class IRI="#PPEO_000008"/>
+        </ObjectExactCardinality>
+    </SubClassOf>
+    <SubClassOf>
+        <Class IRI="#PPEO_000007"/>
+        <ObjectExactCardinality cardinality="1">
+            <ObjectProperty IRI="#hasScale"/>
+            <Class IRI="#PPEO_000012"/>
+        </ObjectExactCardinality>
+    </SubClassOf>
+    <SubClassOf>
+        <Class IRI="#PPEO_000009"/>
+        <Class IRI="#PPEO_000008"/>
+    </SubClassOf>
+    <SubClassOf>
+        <Class IRI="#PPEO_000010"/>
+        <Class IRI="#PPEO_000008"/>
+    </SubClassOf>
+    <SubClassOf>
+        <Class IRI="#PPEO_000016"/>
+        <Class IRI="#PPEO_000023"/>
+    </SubClassOf>
+    <SubClassOf>
+        <Class IRI="#PPEO_000017"/>
+        <Class IRI="#PPEO_000023"/>
+    </SubClassOf>
+    <SubClassOf>
+        <Class IRI="#PPEO_000018"/>
+        <Class IRI="#PPEO_000015"/>
+    </SubClassOf>
+    <SubClassOf>
+        <Class IRI="#PPEO_000022"/>
+        <Class IRI="#PPEO_000015"/>
+    </SubClassOf>
+    <SubClassOf>
+        <Class IRI="#PPEO_000023"/>
+        <DataSomeValuesFrom>
+            <DataProperty IRI="#hasDateTime"/>
+            <Datatype abbreviatedIRI="xsd:dateTime"/>
+        </DataSomeValuesFrom>
+    </SubClassOf>
+    <AsymmetricObjectProperty>
+        <ObjectProperty IRI="#partOf"/>
+    </AsymmetricObjectProperty>
+    <TransitiveObjectProperty>
+        <ObjectProperty IRI="#partOf"/>
+    </TransitiveObjectProperty>
+    <ObjectPropertyDomain>
+        <ObjectProperty IRI="#derivesFrom"/>
+        <Class IRI="#PPEO_000003"/>
+    </ObjectPropertyDomain>
+    <ObjectPropertyDomain>
+        <ObjectProperty IRI="#hasAffiliation"/>
+        <Class IRI="#PPEO_000013"/>
+    </ObjectPropertyDomain>
+    <ObjectPropertyDomain>
+        <ObjectProperty IRI="#hasBiosource"/>
+        <ObjectUnionOf>
+            <Class IRI="#PPEO_000002"/>
+            <Class IRI="#PPEO_000005"/>
+        </ObjectUnionOf>
+    </ObjectPropertyDomain>
+    <ObjectPropertyDomain>
+        <ObjectProperty IRI="#hasContactInstitution"/>
+        <Class IRI="#PPEO_000003"/>
+    </ObjectPropertyDomain>
+    <ObjectPropertyDomain>
+        <ObjectProperty IRI="#hasContactPerson"/>
+        <Class IRI="#PPEO_000003"/>
+    </ObjectPropertyDomain>
+    <ObjectPropertyDomain>
+        <ObjectProperty IRI="#hasCoordinator"/>
+        <ObjectUnionOf>
+            <Class IRI="#PPEO_000001"/>
+            <Class IRI="#PPEO_000002"/>
+        </ObjectUnionOf>
+    </ObjectPropertyDomain>
+    <ObjectPropertyDomain>
+        <ObjectProperty IRI="#hasCountry"/>
+        <Class IRI="#PPEO_000020"/>
+    </ObjectPropertyDomain>
+    <ObjectPropertyDomain>
+        <ObjectProperty IRI="#hasCountryOfOrigin"/>
+        <Class IRI="#PPEO_000004"/>
+    </ObjectPropertyDomain>
+    <ObjectPropertyDomain>
+        <ObjectProperty IRI="#hasMethod"/>
+        <Class IRI="#PPEO_000007"/>
+    </ObjectPropertyDomain>
+    <ObjectPropertyDomain>
+        <ObjectProperty IRI="#hasObservation"/>
+        <Class IRI="#PPEO_000005"/>
+    </ObjectPropertyDomain>
+    <ObjectPropertyDomain>
+        <ObjectProperty IRI="#hasOccurrence"/>
+        <Class IRI="#PPEO_000005"/>
+    </ObjectPropertyDomain>
+    <ObjectPropertyDomain>
+        <ObjectProperty IRI="#hasParticipatingInstitution"/>
+        <ObjectUnionOf>
+            <Class IRI="#PPEO_000001"/>
+            <Class IRI="#PPEO_000002"/>
+        </ObjectUnionOf>
+    </ObjectPropertyDomain>
+    <ObjectPropertyDomain>
+        <ObjectProperty IRI="#hasQuality"/>
+        <Class IRI="#PPEO_000007"/>
+    </ObjectPropertyDomain>
+    <ObjectPropertyDomain>
+        <ObjectProperty IRI="#hasScale"/>
+        <Class IRI="#PPEO_000007"/>
+    </ObjectPropertyDomain>
+    <ObjectPropertyDomain>
+        <ObjectProperty IRI="#hasSetting"/>
+        <Class IRI="#PPEO_000005"/>
+    </ObjectPropertyDomain>
+    <ObjectPropertyDomain>
+        <ObjectProperty IRI="#hasTreatment"/>
+        <Class IRI="#PPEO_000005"/>
+    </ObjectPropertyDomain>
+    <ObjectPropertyDomain>
+        <ObjectProperty IRI="#hasVariable"/>
+        <Class IRI="#PPEO_000006"/>
+    </ObjectPropertyDomain>
+    <ObjectPropertyRange>
+        <ObjectProperty IRI="#derivesFrom"/>
+        <ObjectUnionOf>
+            <Class IRI="#PPEO_000001"/>
+            <Class IRI="#PPEO_000002"/>
+        </ObjectUnionOf>
+    </ObjectPropertyRange>
+    <ObjectPropertyRange>
+        <ObjectProperty IRI="#hasAffiliation"/>
+        <Class IRI="#PPEO_000021"/>
+    </ObjectPropertyRange>
+    <ObjectPropertyRange>
+        <ObjectProperty IRI="#hasBiosource"/>
+        <Class IRI="#PPEO_000004"/>
+    </ObjectPropertyRange>
+    <ObjectPropertyRange>
+        <ObjectProperty IRI="#hasContactInstitution"/>
+        <Class IRI="#PPEO_000021"/>
+    </ObjectPropertyRange>
+    <ObjectPropertyRange>
+        <ObjectProperty IRI="#hasContactPerson"/>
+        <Class IRI="#PPEO_000013"/>
+    </ObjectPropertyRange>
+    <ObjectPropertyRange>
+        <ObjectProperty IRI="#hasCoordinator"/>
+        <Class IRI="#PPEO_000013"/>
+    </ObjectPropertyRange>
+    <ObjectPropertyRange>
+        <ObjectProperty IRI="#hasCountry"/>
+        <Class IRI="#PPEO_000019"/>
+    </ObjectPropertyRange>
+    <ObjectPropertyRange>
+        <ObjectProperty IRI="#hasCountryOfOrigin"/>
+        <Class IRI="#PPEO_000019"/>
+    </ObjectPropertyRange>
+    <ObjectPropertyRange>
+        <ObjectProperty IRI="#hasLocation"/>
+        <Class IRI="#PPEO_000020"/>
+    </ObjectPropertyRange>
+    <ObjectPropertyRange>
+        <ObjectProperty IRI="#hasMethod"/>
+        <Class IRI="#PPEO_000011"/>
+    </ObjectPropertyRange>
+    <ObjectPropertyRange>
+        <ObjectProperty IRI="#hasObservation"/>
+        <Class IRI="#PPEO_000006"/>
+    </ObjectPropertyRange>
+    <ObjectPropertyRange>
+        <ObjectProperty IRI="#hasOccurrence"/>
+        <Class IRI="#PPEO_000023"/>
+    </ObjectPropertyRange>
+    <ObjectPropertyRange>
+        <ObjectProperty IRI="#hasOperator"/>
+        <Class IRI="#PPEO_000013"/>
+    </ObjectPropertyRange>
+    <ObjectPropertyRange>
+        <ObjectProperty IRI="#hasParticipatingInstitution"/>
+        <Class IRI="#PPEO_000021"/>
+    </ObjectPropertyRange>
+    <ObjectPropertyRange>
+        <ObjectProperty IRI="#hasQuality"/>
+        <Class IRI="#PPEO_000008"/>
+    </ObjectPropertyRange>
+    <ObjectPropertyRange>
+        <ObjectProperty IRI="#hasScale"/>
+        <Class IRI="#PPEO_000012"/>
+    </ObjectPropertyRange>
+    <ObjectPropertyRange>
+        <ObjectProperty IRI="#hasSetting"/>
+        <Class IRI="#PPEO_000015"/>
+    </ObjectPropertyRange>
+    <ObjectPropertyRange>
+        <ObjectProperty IRI="#hasStorageLocation"/>
+        <Class IRI="#PPEO_000020"/>
+    </ObjectPropertyRange>
+    <ObjectPropertyRange>
+        <ObjectProperty IRI="#hasTreatment"/>
+        <Class IRI="#PPEO_000018"/>
+    </ObjectPropertyRange>
+    <ObjectPropertyRange>
+        <ObjectProperty IRI="#hasVariable"/>
+        <Class IRI="#PPEO_000007"/>
+    </ObjectPropertyRange>
+    <SubDataPropertyOf>
+        <DataProperty IRI="#hasBlockId"/>
+        <DataProperty IRI="#hasIdentifier"/>
+    </SubDataPropertyOf>
+    <SubDataPropertyOf>
+        <DataProperty IRI="#hasColumnId"/>
+        <DataProperty IRI="#hasIdentifier"/>
+    </SubDataPropertyOf>
+    <SubDataPropertyOf>
+        <DataProperty IRI="#hasCountryCode"/>
+        <DataProperty IRI="#hasIdentifier"/>
+    </SubDataPropertyOf>
+    <SubDataPropertyOf>
+        <DataProperty IRI="#hasDatabaseId"/>
+        <DataProperty IRI="#hasIdentifier"/>
+    </SubDataPropertyOf>
+    <SubDataPropertyOf>
+        <DataProperty IRI="#hasEndDateTime"/>
+        <DataProperty IRI="#hasDateTime"/>
+    </SubDataPropertyOf>
+    <SubDataPropertyOf>
+        <DataProperty IRI="#hasGermplasmAccessionNumber"/>
+        <DataProperty IRI="#hasIdentifier"/>
+    </SubDataPropertyOf>
+    <SubDataPropertyOf>
+        <DataProperty IRI="#hasInstituteCode"/>
+        <DataProperty IRI="#hasIdentifier"/>
+    </SubDataPropertyOf>
+    <SubDataPropertyOf>
+        <DataProperty IRI="#hasMaterialSourceDOI"/>
+        <DataProperty IRI="#hasIdentifier"/>
+    </SubDataPropertyOf>
+    <SubDataPropertyOf>
+        <DataProperty IRI="#hasPlantId"/>
+        <DataProperty IRI="#hasIdentifier"/>
+    </SubDataPropertyOf>
+    <SubDataPropertyOf>
+        <DataProperty IRI="#hasPlotId"/>
+        <DataProperty IRI="#hasIdentifier"/>
+    </SubDataPropertyOf>
+    <SubDataPropertyOf>
+        <DataProperty IRI="#hasPublicReleaseDate"/>
+        <DataProperty IRI="#hasDateTime"/>
+    </SubDataPropertyOf>
+    <SubDataPropertyOf>
+        <DataProperty IRI="#hasReplicateId"/>
+        <DataProperty IRI="#hasIdentifier"/>
+    </SubDataPropertyOf>
+    <SubDataPropertyOf>
+        <DataProperty IRI="#hasRowId"/>
+        <DataProperty IRI="#hasIdentifier"/>
+    </SubDataPropertyOf>
+    <SubDataPropertyOf>
+        <DataProperty IRI="#hasSamplingTime"/>
+        <DataProperty IRI="#hasDateTime"/>
+    </SubDataPropertyOf>
+    <SubDataPropertyOf>
+        <DataProperty IRI="#hasStartDateTime"/>
+        <DataProperty IRI="#hasDateTime"/>
+    </SubDataPropertyOf>
+    <SubDataPropertyOf>
+        <DataProperty IRI="#hasSubmissionDate"/>
+        <DataProperty IRI="#hasDateTime"/>
+    </SubDataPropertyOf>
+    <SubDataPropertyOf>
+        <DataProperty IRI="#hasTaxonId"/>
+        <DataProperty IRI="#hasIdentifier"/>
+    </SubDataPropertyOf>
+    <FunctionalDataProperty>
+        <DataProperty IRI="#hasAddress"/>
+    </FunctionalDataProperty>
+    <FunctionalDataProperty>
+        <DataProperty IRI="#hasAltitude"/>
+    </FunctionalDataProperty>
+    <FunctionalDataProperty>
+        <DataProperty IRI="#hasBlockId"/>
+    </FunctionalDataProperty>
+    <FunctionalDataProperty>
+        <DataProperty IRI="#hasColumnId"/>
+    </FunctionalDataProperty>
+    <FunctionalDataProperty>
+        <DataProperty IRI="#hasCountryCode"/>
+    </FunctionalDataProperty>
+    <FunctionalDataProperty>
+        <DataProperty IRI="#hasDatabaseId"/>
+    </FunctionalDataProperty>
+    <FunctionalDataProperty>
+        <DataProperty IRI="#hasDescription"/>
+    </FunctionalDataProperty>
+    <FunctionalDataProperty>
+        <DataProperty IRI="#hasEndDateTime"/>
+    </FunctionalDataProperty>
+    <FunctionalDataProperty>
+        <DataProperty IRI="#hasEntryNumber"/>
+    </FunctionalDataProperty>
+    <FunctionalDataProperty>
+        <DataProperty IRI="#hasEntryType"/>
+    </FunctionalDataProperty>
+    <FunctionalDataProperty>
+        <DataProperty IRI="#hasExperimentalDesign"/>
+    </FunctionalDataProperty>
+    <FunctionalDataProperty>
+        <DataProperty IRI="#hasGenus"/>
+    </FunctionalDataProperty>
+    <FunctionalDataProperty>
+        <DataProperty IRI="#hasGermplasmAccessionNumber"/>
+    </FunctionalDataProperty>
+    <FunctionalDataProperty>
+        <DataProperty IRI="#hasInstituteCode"/>
+    </FunctionalDataProperty>
+    <FunctionalDataProperty>
+        <DataProperty IRI="#hasLatitude"/>
+    </FunctionalDataProperty>
+    <FunctionalDataProperty>
+        <DataProperty IRI="#hasLicense"/>
+    </FunctionalDataProperty>
+    <FunctionalDataProperty>
+        <DataProperty IRI="#hasLongitude"/>
+    </FunctionalDataProperty>
+    <FunctionalDataProperty>
+        <DataProperty IRI="#hasMaterialSource"/>
+    </FunctionalDataProperty>
+    <FunctionalDataProperty>
+        <DataProperty IRI="#hasMaterialSourceDOI"/>
+    </FunctionalDataProperty>
+    <FunctionalDataProperty>
+        <DataProperty IRI="#hasName"/>
+    </FunctionalDataProperty>
+    <FunctionalDataProperty>
+        <DataProperty IRI="#hasObjective"/>
+    </FunctionalDataProperty>
+    <FunctionalDataProperty>
+        <DataProperty IRI="#hasObservationLevel"/>
+    </FunctionalDataProperty>
+    <FunctionalDataProperty>
+        <DataProperty IRI="#hasOrganismCount"/>
+    </FunctionalDataProperty>
+    <FunctionalDataProperty>
+        <DataProperty IRI="#hasPlantId"/>
+    </FunctionalDataProperty>
+    <FunctionalDataProperty>
+        <DataProperty IRI="#hasPlotId"/>
+    </FunctionalDataProperty>
+    <FunctionalDataProperty>
+        <DataProperty IRI="#hasPublicReleaseDate"/>
+    </FunctionalDataProperty>
+    <FunctionalDataProperty>
+        <DataProperty IRI="#hasReplicationHierarchy"/>
+    </FunctionalDataProperty>
+    <FunctionalDataProperty>
+        <DataProperty IRI="#hasReplicationLevels"/>
+    </FunctionalDataProperty>
+    <FunctionalDataProperty>
+        <DataProperty IRI="#hasRowId"/>
+    </FunctionalDataProperty>
+    <FunctionalDataProperty>
+        <DataProperty IRI="#hasSeason"/>
+    </FunctionalDataProperty>
+    <FunctionalDataProperty>
+        <DataProperty IRI="#hasSpeciesAuthority"/>
+    </FunctionalDataProperty>
+    <FunctionalDataProperty>
+        <DataProperty IRI="#hasSpecificEpithet"/>
+    </FunctionalDataProperty>
+    <FunctionalDataProperty>
+        <DataProperty IRI="#hasStartDateTime"/>
+    </FunctionalDataProperty>
+    <FunctionalDataProperty>
+        <DataProperty IRI="#hasSubmissionDate"/>
+    </FunctionalDataProperty>
+    <FunctionalDataProperty>
+        <DataProperty IRI="#isActive"/>
+    </FunctionalDataProperty>
+    <DataPropertyDomain>
+        <DataProperty IRI="#hasAddress"/>
+        <Class IRI="#PPEO_000020"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="#hasAltitude"/>
+        <Class IRI="#PPEO_000020"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="#hasAssociatedPublication"/>
+        <Class IRI="#PPEO_000003"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="#hasBlockId"/>
+        <Class IRI="#PPEO_000005"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="#hasColumnId"/>
+        <Class IRI="#PPEO_000005"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="#hasCountryCode"/>
+        <Class IRI="#PPEO_000019"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="#hasDataFile"/>
+        <Class IRI="#PPEO_000003"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="#hasEmailContact"/>
+        <Class IRI="#PPEO_000013"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="#hasExperimentalDesign"/>
+        <Class IRI="#PPEO_000002"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="#hasGenus"/>
+        <Class IRI="#PPEO_000004"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="#hasGermplasmAccessionNumber"/>
+        <Class IRI="#PPEO_000004"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="#hasInstituteCode"/>
+        <Class IRI="#PPEO_000021"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="#hasLatitude"/>
+        <Class IRI="#PPEO_000020"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="#hasLicense"/>
+        <Class IRI="#PPEO_000003"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="#hasLifeStage"/>
+        <Class IRI="#PPEO_000004"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="#hasLongitude"/>
+        <Class IRI="#PPEO_000020"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="#hasMaterialSource"/>
+        <Class IRI="#PPEO_000004"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="#hasMaterialSourceDOI"/>
+        <Class IRI="#PPEO_000004"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="#hasObjective"/>
+        <Class IRI="#PPEO_000001"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="#hasObservationLevel"/>
+        <Class IRI="#PPEO_000005"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="#hasPlantId"/>
+        <Class IRI="#PPEO_000005"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="#hasPlotId"/>
+        <Class IRI="#PPEO_000005"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="#hasPublicReleaseDate"/>
+        <Class IRI="#PPEO_000003"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="#hasReplicateId"/>
+        <Class IRI="#PPEO_000005"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="#hasReplicationHierarchy"/>
+        <Class IRI="#PPEO_000005"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="#hasReplicationLevels"/>
+        <Class IRI="#PPEO_000005"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="#hasRowId"/>
+        <Class IRI="#PPEO_000005"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="#hasSeason"/>
+        <Class IRI="#PPEO_000006"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="#hasSpeciesAuthority"/>
+        <Class IRI="#PPEO_000004"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="#hasSpecificEpithet"/>
+        <Class IRI="#PPEO_000004"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="#hasSubmissionDate"/>
+        <Class IRI="#PPEO_000003"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="#hasSubtaxon"/>
+        <Class IRI="#PPEO_000004"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="#hasSubtaxonAuthority"/>
+        <Class IRI="#PPEO_000004"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="#hasTaxonId"/>
+        <Class IRI="#PPEO_000004"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="#hasTreatmentFactor"/>
+        <Class IRI="#PPEO_000018"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="#hasTreatmentModality"/>
+        <Class IRI="#PPEO_000018"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="#hasType"/>
+        <ObjectUnionOf>
+            <Class IRI="#PPEO_000002"/>
+            <Class IRI="#PPEO_000020"/>
+        </ObjectUnionOf>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="#hasValue"/>
+        <Class IRI="#PPEO_000006"/>
+    </DataPropertyDomain>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasAbbreviation"/>
+        <Datatype abbreviatedIRI="xsd:string"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasAddress"/>
+        <Datatype abbreviatedIRI="xsd:string"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasAltitude"/>
+        <Datatype abbreviatedIRI="xsd:float"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasAssociatedPublication"/>
+        <DataUnionOf>
+            <Datatype abbreviatedIRI="xsd:anyURI"/>
+            <Datatype abbreviatedIRI="xsd:string"/>
+        </DataUnionOf>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasBlockId"/>
+        <Datatype abbreviatedIRI="xsd:string"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasColumnId"/>
+        <Datatype abbreviatedIRI="xsd:string"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasCountryCode"/>
+        <Datatype abbreviatedIRI="xsd:string"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasDataFile"/>
+        <Datatype abbreviatedIRI="xsd:anyURI"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasDatabaseId"/>
+        <DataUnionOf>
+            <Datatype abbreviatedIRI="xsd:anyURI"/>
+            <Datatype abbreviatedIRI="xsd:string"/>
+        </DataUnionOf>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasDateTime"/>
+        <Datatype abbreviatedIRI="xsd:dateTime"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasDescription"/>
+        <Datatype abbreviatedIRI="xsd:string"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasEmailContact"/>
+        <Datatype abbreviatedIRI="xsd:string"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasEndDateTime"/>
+        <Datatype abbreviatedIRI="xsd:dateTime"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasEntryNumber"/>
+        <Datatype abbreviatedIRI="xsd:int"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasEntryType"/>
+        <Datatype abbreviatedIRI="xsd:string"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasExperimentalDesign"/>
+        <Datatype abbreviatedIRI="xsd:string"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasGenus"/>
+        <Datatype abbreviatedIRI="xsd:string"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasGermplasmAccessionNumber"/>
+        <DataUnionOf>
+            <Datatype abbreviatedIRI="xsd:anyURI"/>
+            <Datatype abbreviatedIRI="xsd:string"/>
+        </DataUnionOf>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasIdentifier"/>
+        <DataUnionOf>
+            <Datatype abbreviatedIRI="xsd:anyURI"/>
+            <Datatype abbreviatedIRI="xsd:string"/>
+        </DataUnionOf>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasInstituteCode"/>
+        <Datatype abbreviatedIRI="xsd:string"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasLatitude"/>
+        <Datatype abbreviatedIRI="xsd:float"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasLicense"/>
+        <Datatype abbreviatedIRI="xsd:string"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasLifeStage"/>
+        <DataUnionOf>
+            <Datatype abbreviatedIRI="xsd:anyURI"/>
+            <Datatype abbreviatedIRI="xsd:string"/>
+        </DataUnionOf>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasLongitude"/>
+        <Datatype abbreviatedIRI="xsd:float"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasMaterialSource"/>
+        <Datatype abbreviatedIRI="xsd:string"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasMaterialSourceDOI"/>
+        <Datatype abbreviatedIRI="xsd:anyURI"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasName"/>
+        <Datatype abbreviatedIRI="xsd:string"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasObjective"/>
+        <Datatype abbreviatedIRI="xsd:string"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasObservationLevel"/>
+        <Datatype abbreviatedIRI="xsd:string"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasOrganismCount"/>
+        <DataUnionOf>
+            <Datatype abbreviatedIRI="xsd:int"/>
+            <Datatype abbreviatedIRI="xsd:string"/>
+        </DataUnionOf>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasPlantBody"/>
+        <DataUnionOf>
+            <Datatype abbreviatedIRI="xsd:anyURI"/>
+            <Datatype abbreviatedIRI="xsd:string"/>
+        </DataUnionOf>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasPlantId"/>
+        <Datatype abbreviatedIRI="xsd:string"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasPlantStructureDevelopmentStage"/>
+        <DataUnionOf>
+            <Datatype abbreviatedIRI="xsd:anyURI"/>
+            <Datatype abbreviatedIRI="xsd:string"/>
+        </DataUnionOf>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasPlotId"/>
+        <Datatype abbreviatedIRI="xsd:string"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasPublicReleaseDate"/>
+        <Datatype abbreviatedIRI="xsd:dateTime"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasReplicateId"/>
+        <Datatype abbreviatedIRI="xsd:string"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasReplicationHierarchy"/>
+        <Datatype abbreviatedIRI="xsd:string"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasReplicationLevels"/>
+        <Datatype abbreviatedIRI="xsd:string"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasRowId"/>
+        <Datatype abbreviatedIRI="xsd:string"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasSamplingTime"/>
+        <Datatype abbreviatedIRI="xsd:dateTime"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasSeason"/>
+        <Datatype abbreviatedIRI="xsd:string"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasSpeciesAuthority"/>
+        <Datatype abbreviatedIRI="xsd:string"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasSpecificEpithet"/>
+        <Datatype abbreviatedIRI="xsd:string"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasStartDateTime"/>
+        <Datatype abbreviatedIRI="xsd:dateTime"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasSubmissionDate"/>
+        <Datatype abbreviatedIRI="xsd:dateTime"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasSubtaxon"/>
+        <Datatype abbreviatedIRI="xsd:string"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasSubtaxonAuthority"/>
+        <Datatype abbreviatedIRI="xsd:string"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasTaxonId"/>
+        <DataUnionOf>
+            <Datatype abbreviatedIRI="xsd:anyURI"/>
+            <Datatype abbreviatedIRI="xsd:string"/>
+        </DataUnionOf>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasTreatmentFactor"/>
+        <DataUnionOf>
+            <Datatype abbreviatedIRI="xsd:anyURI"/>
+            <Datatype abbreviatedIRI="xsd:string"/>
+        </DataUnionOf>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasTreatmentModality"/>
+        <Datatype abbreviatedIRI="xsd:string"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#hasType"/>
+        <Datatype abbreviatedIRI="xsd:string"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="#isActive"/>
+        <Datatype abbreviatedIRI="xsd:boolean"/>
+    </DataPropertyRange>
+    <AnnotationAssertion>
+        <AnnotationProperty IRI="#hasExactSynonym"/>
+        <IRI>#PPEO_000001</IRI>
+        <Literal datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">investigation
+(http://purl.obolibrary.org/obo/OBI_0000066)</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty IRI="#hasExactSynonym"/>
+        <IRI>#PPEO_000001</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">trial</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#PPEO_000001</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">investigation</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty IRI="#hasExactSynonym"/>
+        <IRI>#PPEO_000002</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">experiment</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty IRI="#hasExactSynonym"/>
+        <IRI>#PPEO_000002</IRI>
+        <Literal datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">investigation
+(http://purl.obolibrary.org/obo/OBI_0000066)</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#PPEO_000002</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">study</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty IRI="#hasExactSynonym"/>
+        <IRI>#PPEO_000003</IRI>
+        <Literal datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">data set:
+(http://purl.obolibrary.org/obo/IAO_0000100)</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
+        <IRI>#PPEO_000003</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">A MIAPPE-compliant dataset, derived from a study or investigation</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#PPEO_000003</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">dataset</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty IRI="#hasExactSynonym"/>
+        <IRI>#PPEO_000004</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">germplasm</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty IRI="#hasRelatedSynonym"/>
+        <IRI>#PPEO_000004</IRI>
+        <Literal datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">material sample
+http://purl.obolibrary.org/obo/OBI_0000747</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
+        <IRI>#PPEO_000004</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">An organism that was the subject of the study and/or was observed in an observation unit</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#PPEO_000004</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">biosource</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty IRI="#hasExactSynonym"/>
+        <IRI>#PPEO_000005</IRI>
+        <Literal datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">TODO: Missing</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty IRI="#hasExactSynonym"/>
+        <IRI>#PPEO_000005</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">experiment unit</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty IRI="#hasRelatedSynonym"/>
+        <IRI>#PPEO_000005</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">sample</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#PPEO_000005</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">observation unit</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty IRI="#hasExactSynonym"/>
+        <IRI>#PPEO_000006</IRI>
+        <Literal datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">data acquisition/information acquisition
+(http://purl.obolibrary.org/obo/OBI_0600013)</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#PPEO_000006</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">observation</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty IRI="#hasExactSynonym"/>
+        <IRI>#PPEO_000007</IRI>
+        <Literal datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">variable:
+(http://purl.obolibrary.org/obo/OBI_0000750)</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#PPEO_000007</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">observation variable</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty IRI="#hasExactSynonym"/>
+        <IRI>#PPEO_000008</IRI>
+        <Literal datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">quality:
+(http://purl.obolibrary.org/obo/BFO_0000019)</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#PPEO_000008</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">quality</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty IRI="#hasExactSynonym"/>
+        <IRI>#PPEO_000009</IRI>
+        <Literal datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">phenotype:
+(http://purl.obolibrary.org/obo/OGMS_0000023)</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#PPEO_000009</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">trait</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty IRI="#hasExactSynonym"/>
+        <IRI>#PPEO_000010</IRI>
+        <Literal datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">environmental feature
+(http://purl.obolibrary.org/obo/ENVO_00002297)</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#PPEO_000010</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">environment feature</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty IRI="#hasExactSynonym"/>
+        <IRI>#PPEO_000011</IRI>
+        <Literal datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">protocol:
+(http://purl.obolibrary.org/obo/OBI_0000272)</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#PPEO_000011</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">method</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty IRI="#hasExactSynonym"/>
+        <IRI>#PPEO_000012</IRI>
+        <Literal datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">measurement unit label
+(http://purl.obolibrary.org/obo/IAO_0000003)</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#PPEO_000012</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">scale</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty IRI="#hasExactSynonym"/>
+        <IRI>#PPEO_000013</IRI>
+        <Literal datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">type of homo sapiens / bioinformation resource centre contact person (/OBI_0001883)</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#PPEO_000013</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">person</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty IRI="#hasExactSynonym"/>
+        <IRI>#PPEO_000015</IRI>
+        <Literal datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">TODO: Missing</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
+        <IRI>#PPEO_000015</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">A broad description of the conditions of the observation unit, be they actively induced (treatment) or passive (environment). Detailed measurements of the conditions should be recorded as observations.</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#PPEO_000015</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">setting</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty IRI="#hasExactSynonym"/>
+        <IRI>#PPEO_000016</IRI>
+        <Literal datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">unplanned occurrence effecting an investigation (/OBI_0000076)</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
+        <IRI>#PPEO_000016</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">An inadvertent occurrence, e.g.: a flood, a locust swarm.</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#PPEO_000016</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">event</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty IRI="#hasExactSynonym"/>
+        <IRI>#PPEO_000017</IRI>
+        <Literal datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">planned process: (/OBI_0000011)</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
+        <IRI>#PPEO_000017</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">A deliberate occurrence, e.g.: sowing, transplanting, pollination.</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#PPEO_000017</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">operation</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty IRI="#hasExactSynonym"/>
+        <IRI>#PPEO_000018</IRI>
+        <Literal datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">anthropogenic environmental process (/ENVO_02500027)</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
+        <IRI>#PPEO_000018</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">An actively induced setting of the observation unit, e.g.: irrigation regime, nutrient regime.</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#PPEO_000018</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">treatment</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty IRI="#hasExactSynonym"/>
+        <IRI>#PPEO_000019</IRI>
+        <Literal datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">national geopolitical entity: (/ENVO_00000009)</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
+        <IRI>#PPEO_000019</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">A country in the world where the study took place</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#PPEO_000019</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">country</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty IRI="#hasExactSynonym"/>
+        <IRI>#PPEO_000020</IRI>
+        <Literal datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">geographic location: (/GAZ_00000448)</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty IRI="#hasExactSynonym"/>
+        <IRI>#PPEO_000020</IRI>
+        <Literal datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">site (/BFO_0000029)</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#PPEO_000020</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">location</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty IRI="#hasExactSynonym"/>
+        <IRI>#PPEO_000021</IRI>
+        <Literal datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">organization (/OBI_0000245)</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
+        <IRI>#PPEO_000021</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">An institution (academic or industrial) involved in the investigation or study, or responsible for a given dataset</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#PPEO_000021</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">institution</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty IRI="#hasExactSynonym"/>
+        <IRI>#PPEO_000022</IRI>
+        <Literal datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">environment system: (/ENVO_01000254)</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
+        <IRI>#PPEO_000022</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">A passive setting of the observation unit, e.g.: mean precipitation, mean daily temperature.</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#PPEO_000022</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">environment</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty IRI="#hasExactSynonym"/>
+        <IRI>#PPEO_000023</IRI>
+        <Literal datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">process: (/BFO_0000015)</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
+        <IRI>#PPEO_000023</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">A discrete change to the state of the observation unit that happened at a given point in time, be it deliberate (operation) or inadvertent (event).</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#PPEO_000023</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">occurrence</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#derivesFrom</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">derives from</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasAbbreviation</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has abbreviation</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasAddress</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has address</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasAffiliation</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has affiliation</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
+        <IRI>#hasAltitude</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">altitude of a location in metres</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasAltitude</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has altitude</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasAssociatedPublication</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has associated publication</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasBiosource</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has biosource</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasBlockId</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has block identifier</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasColumnId</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has column identifier</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasContactInstitution</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has contact institution</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasContactPerson</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has contact person</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty IRI="#hasExactSynonym"/>
+        <IRI>#hasCoordinator</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has lead person</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasCoordinator</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has coordinator</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasCountry</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has country</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasCountryCode</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has country code</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasCountryOfOrigin</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has country of origin</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasDataFile</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has data file</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasDatabaseId</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has database identifier</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasDateTime</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has date-time</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasDescription</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has description</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
+        <IRI>#hasEmailContact</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">the e-mail address of a person</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasEmailContact</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has e-mail contact</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasEndDateTime</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has end date-time</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasEntryNumber</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has entry number</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasEntryType</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has entry type</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasExactSynonym</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has exact synonym</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasExperimentalDesign</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has experimental design</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasGenus</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has genus</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasGermplasmAccessionNumber</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has germplasm accession number</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasIdentifier</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has identifier</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasInstituteCode</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has institute code</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
+        <IRI>#hasLatitude</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">latitude of a location in degrees, in the decimal system</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasLatitude</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has latitude</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasLicense</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has license</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasLifeStage</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has life stage</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasLocation</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has location</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
+        <IRI>#hasLongitude</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">longitude of a location in degrees, in the decimal system</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasLongitude</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has longitude</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasMaterialSource</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has material source</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasMaterialSourceDOI</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has material source DOI</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasMethod</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has method</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasName</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has name</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasObjective</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has objective</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasObservation</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has observation</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasObservationLevel</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has observation level</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasOccurrence</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has occurrence</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasOperator</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has operator</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasOrganismCount</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has organism count</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasParticipatingInstitution</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has participating institution</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasPlantBody</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has plant body</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasPlantId</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has plant identifier</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasPlantStructureDevelopmentStage</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has plant structure development stage</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasPlotId</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has plot identifier</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasPublicReleaseDate</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has public release date</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasQuality</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has quality</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasRelatedSynonym</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has related synonym</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasReplicateId</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has replicate identifier</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
+        <IRI>#hasReplicationHierarchy</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">e.g.: block&gt;rep&gt;plot</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasReplicationHierarchy</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has replication hierarchy</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
+        <IRI>#hasReplicationLevels</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">e.g.: block:1, plot:894, rep:1</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasReplicationLevels</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has replication levels</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasRowId</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has row identifier</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasSamplingTime</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has sampling time</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasScale</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has scale</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasSeason</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has season</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasSetting</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has setting</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasSpeciesAuthority</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has species authority</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasSpecificEpithet</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has specific epithet</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasStartDateTime</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has start date-time</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasStorageLocation</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has storage location</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasSubmissionDate</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has submission date</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasSubtaxon</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has subtaxon</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasSubtaxonAuthority</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has subtaxon authority</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasTaxonId</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has taxon identifier</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasTreatment</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has treatment</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasTreatmentFactor</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has treatment factor</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasTreatmentModality</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has treatment modality</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasType</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has type</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasValue</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has value</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#hasVariable</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">has variable</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#isActive</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">is active</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#partOf</IRI>
+        <Literal xml:lang="en" datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">part of</Literal>
+    </AnnotationAssertion>
+</Ontology>
+
+
+
+<!-- Generated by the OWL API (version 4.2.6.20160910-2108) https://github.com/owlcs/owlapi -->
+


### PR DESCRIPTION
{BFO,IAO,OBI,ENVO,STATO}

use of 'has_ontology_recommendation' class annotation metadata to suggest possible classes.

first pass at mapping in AGRO too (which imports from the above resources)
@cpommier, @hcwi, @DanFaria , please have a look